### PR TITLE
Add improvements for cross-compiling with CGO + build system fix

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -65,15 +65,16 @@ pub const BuildStep = struct {
             // Set zig as the CGO compiler
             const target = self.opts.target;
             const cc = b.fmt(
-                "zig cc -target {s}-{s}",
-                .{ @tagName(target.result.cpu.arch), @tagName(target.result.os.tag) },
+                "zig cc -target {s}-{s}-{s}",
+                .{ @tagName(target.result.cpu.arch), @tagName(target.result.os.tag), @tagName(target.result.abi) },
             );
             try env.put("CC", cc);
             const cxx = b.fmt(
-                "zig c++ -target {s}-{s}",
-                .{ @tagName(target.result.cpu.arch), @tagName(target.result.os.tag) },
+                "zig c++ -target {s}-{s}-{s}",
+                .{ @tagName(target.result.cpu.arch), @tagName(target.result.os.tag), @tagName(target.result.abi) },
             );
             try env.put("CXX", cxx);
+            try env.put("GOOS", @tagName(target.result.os.tag));
 
             // Tell the linker we are statically linking
             go_args.appendSlice(&.{ "--ldflags", "-linkmode=external -extldflags=-static" }) catch @panic("OOM");

--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,10 @@ pub fn addExecutable(b: *std.Build, options: BuildStep.Options) *BuildStep {
     return BuildStep.create(b, options);
 }
 
+pub fn build(b: *std.Build) void {
+    _ = b;
+}
+
 /// Runs `go build` with relevant flags
 pub const BuildStep = struct {
     step: std.Build.Step,


### PR DESCRIPTION
Hello, this PR adds two changes:

- A fix I was encountering with `zig 0.13.0` where I was getting an error `error: root struct of file 'build' has no member named 'build'` whenever zig4go was added as a package in `build.zig.zon`, regardless of it being used in `build.zig`. The issue seemed to come from an expectation that `pub fn build(b: *std.Build) void {}` exists, so I added a stub function.
- Adding the target abi to the `CC` and `CXX` build targets as well as setting the `GOOS` env var. These together fixed a compilation issue I was having when cross-compiling an ebitengine project to Windows from WSL